### PR TITLE
New credential definition

### DIFF
--- a/src/lib/constants.ts
+++ b/src/lib/constants.ts
@@ -18,7 +18,8 @@ export const CREDENTIAL_VERIFIER_ENDPOINT =
   'https://verifier-server.asml.berkmancenter.org'
 
 // Credential Definition IDs (not sensitive). In prod case we probably need to interact with an API
-export const AGE_CRED_DEF_ID = 'VPSZ5XQA8EULcjUxL9HTfQ:3:CL:39:mdl'
+export const AGE_CRED_DEF_ID =
+  'VPSZ5XQA8EULcjUxL9HTfQ:3:CL:39:mock_mobile_drivers_license'
 export const ACCOUNT_CRED_DEF_ID = 'VPSZ5XQA8EULcjUxL9HTfQ:3:CL:59:x_account'
 // HACK
 // Yes, this is exactly what it looks like. It's a hard-coded constant


### PR DESCRIPTION
## Summary
There is an issue when going through the age verification. Wallet is not detecting the appropriate credential to use.

# Solution
Since we wanted to add a new title to our credentials we had to change the naming on the credential definition. Changed it to `VPSZ5XQA8EULcjUxL9HTfQ:3:CL:39:mock_mobile_drivers_license`
