### PR TITLE
Redesign Verifiable Credentials Settings with Card Layout

### DIFF
--- a/src/screens/Settings/VerifiableCredentialsSettings.tsx
+++ b/src/screens/Settings/VerifiableCredentialsSettings.tsx
@@ -1,3 +1,24 @@
+/**
+ * TODO: When adding new verification types, update the following:
+ *
+ * 1. src/lib/api/credentials/verification-types.ts
+ *    - Add new type to VerificationType union (e.g., 'instagram' | 'reddit')
+ *    - Add corresponding field to VerificationStatusMap interface
+ *
+ * 2. src/screens/Settings/VerifiableCredentialsSettings.tsx
+ *    - Update isRealVerificationType() function to include new types
+ *    - Change card status from 'coming_soon' to 'not_verified'
+ *    - Add new badge icon import
+ *
+ * 3. src/components/verification/VerificationBadges.tsx
+ *    - Add new verification badge component
+ *    - Update badge rendering logic
+ *
+ * 4. Verification system backend
+ *    - Implement actual verification flow for new platform
+ *    - Add credential definition IDs
+ *    - Update proof request templates
+ */
 import {View} from 'react-native'
 import {msg, Trans} from '@lingui/macro'
 import {useLingui} from '@lingui/react'
@@ -14,6 +35,8 @@ import {
   useVerifiableCredentialsDialogControl,
   VerifiableCredentialsDialogScreenID,
 } from '#/components/dialogs/VerifiableCredentialsDialog'
+import {AccountVerificationBadge} from '#/components/icons/AccountVerificationBadge'
+import {AgeVerificationBadge} from '#/components/icons/AgeVerificationBadge'
 import {Shield_Stroke2_Corner0_Rounded as ShieldIcon} from '#/components/icons/Shield'
 import {VerifiedCheck} from '#/components/icons/VerifiedCheck'
 import * as Layout from '#/components/Layout'
@@ -24,6 +47,62 @@ type Props = NativeStackScreenProps<
   'VerifiableCredentialsSettings'
 >
 
+// Define verification cards for clean card-based layout
+interface VerificationCard {
+  id: VerificationType | string
+  title: string
+  description: string
+  icon: React.ComponentType<any>
+  status: 'verified' | 'not_verified' | 'coming_soon'
+  platform?: string
+  actionLabel?: string
+}
+
+const VERIFICATION_CARDS: VerificationCard[] = [
+  {
+    id: 'age',
+    title: 'Age Verification',
+    description: "Verify your age using mobile driver's license",
+    icon: AgeVerificationBadge,
+    status: 'not_verified', // Will be updated dynamically
+    actionLabel: 'Verify Age',
+  },
+  {
+    id: 'account',
+    title: 'X.com Account Verification',
+    description: 'Verify your X.com account ownership',
+    icon: AccountVerificationBadge,
+    status: 'not_verified',
+    platform: 'X.com',
+    actionLabel: 'Verify X.com Account',
+  },
+  // Future verification cards - Coming Soon
+  {
+    id: 'instagram',
+    title: 'Instagram Account Verification',
+    description: 'Verify your Instagram account ownership',
+    icon: ShieldIcon,
+    status: 'coming_soon',
+    platform: 'Instagram',
+  },
+  {
+    id: 'reddit',
+    title: 'Reddit Account Verification',
+    description: 'Verify your Reddit account ownership',
+    icon: ShieldIcon,
+    status: 'coming_soon',
+    platform: 'Reddit',
+  },
+  {
+    id: 'linkedin',
+    title: 'LinkedIn Profile Verification',
+    description: 'Verify your LinkedIn professional profile',
+    icon: ShieldIcon,
+    status: 'coming_soon',
+    platform: 'LinkedIn',
+  },
+]
+
 export function VerifiableCredentialsSettingsScreen({}: Props) {
   const {_} = useLingui()
   const t = useTheme()
@@ -32,6 +111,11 @@ export function VerifiableCredentialsSettingsScreen({}: Props) {
 
   // Persistent state from PDS
   const {status: credentialStatus, isLoading, actions} = useVerificationStatus()
+
+  // Ensure we work with implemented verification types (e.g. age, account)
+  const isRealVerificationType = (id: string): id is VerificationType => {
+    return id === 'age' || id === 'account'
+  }
 
   const handleVerifyCredential = async (type: VerificationType) => {
     try {
@@ -64,10 +148,15 @@ export function VerifiableCredentialsSettingsScreen({}: Props) {
     })
   }
 
-  const getCredentialStatusText = (type: VerificationType) => {
+  const getCredentialStatusText = (type: string) => {
     if (isLoading) {
       return _(msg`Loading...`)
     }
+
+    if (!isRealVerificationType(type)) {
+      return _(msg`Not verified`)
+    }
+
     const status = credentialStatus[type]
     if (status.verified) {
       return _(msg`Verified`)
@@ -75,11 +164,109 @@ export function VerifiableCredentialsSettingsScreen({}: Props) {
     return _(msg`Not verified`)
   }
 
-  const getCredentialStatusColor = (type: 'age' | 'account') => {
+  const getCredentialStatusColor = (type: string) => {
+    if (!isRealVerificationType(type)) {
+      return t.atoms.text_contrast_medium.color
+    }
+
     const status = credentialStatus[type]
     return status.verified
       ? t.palette.positive_700
       : t.atoms.text_contrast_medium.color
+  }
+
+  const getCardStatus = (
+    card: VerificationCard,
+  ): VerificationCard['status'] => {
+    if (card.status === 'coming_soon') return 'coming_soon'
+
+    if (!isRealVerificationType(card.id)) {
+      console.warn(`Unknown verification type: ${card.id}`)
+      return 'not_verified'
+    }
+
+    const status = credentialStatus[card.id]
+    return status?.verified ? 'verified' : 'not_verified'
+  }
+
+  const renderVerificationCard = (card: VerificationCard) => {
+    const status = getCardStatus(card)
+    const isVerified = status === 'verified'
+    const isComingSoon = status === 'coming_soon'
+    const IconComponent = card.icon
+
+    return (
+      <View
+        key={card.id}
+        style={[
+          a.border,
+          a.rounded_md,
+          a.p_md,
+          a.mb_md,
+          t.atoms.border_contrast_low,
+          isComingSoon ? t.atoms.bg_contrast_25 : t.atoms.bg,
+          {opacity: isComingSoon ? 0.6 : 1},
+        ]}>
+        {/* Card Header */}
+        <View style={[a.flex_row, a.align_center, a.justify_between, a.mb_sm]}>
+          <View style={[a.flex_row, a.align_center, a.gap_sm]}>
+            <View
+              style={[
+                a.align_center,
+                a.justify_center,
+                {width: 32, height: 32},
+              ]}>
+              <IconComponent size="lg" fill={t.atoms.text.color} />
+            </View>
+            <View>
+              <Text style={[a.font_bold, a.text_md]}>{card.title}</Text>
+              {card.platform && (
+                <Text
+                  style={[a.text_xs, t.atoms.text_contrast_medium, a.mt_xs]}>
+                  {card.platform}
+                </Text>
+              )}
+            </View>
+          </View>
+
+          <View style={[a.flex_row, a.align_center, a.gap_xs]}>
+            {!isComingSoon && (
+              <Text
+                style={[{color: getCredentialStatusColor(card.id)}, a.text_sm]}>
+                {getCredentialStatusText(card.id)}
+              </Text>
+            )}
+            {isVerified && (
+              <VerifiedCheck size="sm" fill={t.palette.positive_700} />
+            )}
+            {isComingSoon && (
+              <Text style={[a.text_xs, t.atoms.text_contrast_medium]}>
+                Coming Soon
+              </Text>
+            )}
+          </View>
+        </View>
+
+        {/* Card Description */}
+        <Text style={[a.text_sm, t.atoms.text_contrast_medium, a.mb_sm]}>
+          {card.description}
+        </Text>
+
+        {/* Card Action */}
+        {!isComingSoon && (
+          <SettingsList.PressableItem
+            onPress={() => handleVerifyCredential(card.id as VerificationType)}
+            label={_(msg`Verify your ${card.title.toLowerCase()}`)}
+            disabled={isVerified}
+            style={[a.mt_xs]}>
+            <SettingsList.ItemText>
+              <Text>{card.actionLabel || `Verify ${card.title}`}</Text>
+            </SettingsList.ItemText>
+            <SettingsList.Chevron />
+          </SettingsList.PressableItem>
+        )}
+      </View>
+    )
   }
 
   return (
@@ -94,68 +281,42 @@ export function VerifiableCredentialsSettingsScreen({}: Props) {
         <Layout.Header.Slot />
       </Layout.Header.Outer>
       <Layout.Content>
-        <SettingsList.Container>
-          <SettingsList.Item>
-            <SettingsList.ItemIcon icon={ShieldIcon} />
-            <SettingsList.ItemText>
-              <Trans>Age Verification</Trans>
-            </SettingsList.ItemText>
-            <View style={[a.flex_row, a.align_center, a.gap_xs]}>
-              <Text
-                style={[{color: getCredentialStatusColor('age')}, a.text_sm]}>
-                {getCredentialStatusText('age')}
-              </Text>
-              {credentialStatus.age.verified && (
-                <VerifiedCheck size="sm" fill={t.palette.positive_700} />
-              )}
-            </View>
-          </SettingsList.Item>
-          <SettingsList.PressableItem
-            onPress={() => handleVerifyCredential('age')}
-            label={_(msg`Verify your age`)}
-            disabled={credentialStatus.age.verified}>
-            <SettingsList.ItemIcon icon={ShieldIcon} />
-            <SettingsList.ItemText>
-              <Trans>Verify Age</Trans>
-            </SettingsList.ItemText>
-            <SettingsList.Chevron />
-          </SettingsList.PressableItem>
+        <View style={[a.px_md, a.py_lg]}>
+          {/* Available Verifications */}
+          <Text style={[a.font_bold, a.text_lg, a.mb_md]}>
+            <Trans>Available Verifications</Trans>
+          </Text>
 
-          <SettingsList.Divider />
+          {VERIFICATION_CARDS.filter(
+            card => getCardStatus(card) !== 'coming_soon',
+          ).map(renderVerificationCard)}
 
-          <SettingsList.Item>
-            <SettingsList.ItemIcon icon={ShieldIcon} />
-            <SettingsList.ItemText>
-              <Trans>Account Verification</Trans>
-            </SettingsList.ItemText>
-            <View style={[a.flex_row, a.align_center, a.gap_xs]}>
-              <Text
-                style={[
-                  {color: getCredentialStatusColor('account')},
-                  a.text_sm,
-                ]}>
-                {getCredentialStatusText('account')}
-              </Text>
-              {credentialStatus.account.verified && (
-                <VerifiedCheck size="sm" fill={t.palette.positive_700} />
-              )}
-            </View>
-          </SettingsList.Item>
-          <SettingsList.PressableItem
-            onPress={() => handleVerifyCredential('account')}
-            label={_(msg`Verify your social media accounts`)}
-            disabled={credentialStatus.account.verified}>
-            <SettingsList.ItemIcon icon={ShieldIcon} />
-            <SettingsList.ItemText>
-              <Trans>Verify Accounts</Trans>
-            </SettingsList.ItemText>
-            <SettingsList.Chevron />
-          </SettingsList.PressableItem>
+          {/* Coming Soon Section */}
+          <View style={[a.mt_xl, a.mb_lg]}>
+            <Text
+              style={[
+                a.font_bold,
+                a.text_lg,
+                a.mb_md,
+                t.atoms.text_contrast_medium,
+              ]}>
+              <Trans>Coming Soon</Trans>
+            </Text>
+            <Text style={[a.text_sm, t.atoms.text_contrast_medium, a.mb_md]}>
+              <Trans>
+                We're working on adding more verification options to help you
+                build trust and credibility.
+              </Trans>
+            </Text>
+          </View>
 
-          <SettingsList.Divider />
+          {VERIFICATION_CARDS.filter(
+            card => getCardStatus(card) === 'coming_soon',
+          ).map(renderVerificationCard)}
 
-          <SettingsList.Item>
-            <SettingsList.ItemText
+          {/* Info Section */}
+          <View style={[a.mt_xl, a.p_md, a.rounded_md, t.atoms.bg_contrast_25]}>
+            <Text
               style={[
                 a.text_sm,
                 t.atoms.text_contrast_medium,
@@ -166,9 +327,9 @@ export function VerifiableCredentialsSettingsScreen({}: Props) {
                 ownership without revealing unnecessary personal information.
                 Your data stays private and secure in your wallet.
               </Trans>
-            </SettingsList.ItemText>
-          </SettingsList.Item>
-        </SettingsList.Container>
+            </Text>
+          </View>
+        </View>
       </Layout.Content>
     </Layout.Screen>
   )


### PR DESCRIPTION
## Changes
- Replace flat list with card based design
- Add "X.com Account Verification" label (was generic "Account Verification")
- Include "Coming Soon" section for future platforms (Instagram, Reddit, LinkedIn as examples)
- Use actual verification badge icons instead of generic shield

## Note
Added a TODO at the beginning of the VerifiableCredentialSetting file with a detailed todo of how to update the verification types, to support other verification methods in the future once supported. 