### PR TITLE
Add Demo Warning Banners to Verifiable Credentials Feature

### DIFF
--- a/src/screens/Settings/Settings.tsx
+++ b/src/screens/Settings/Settings.tsx
@@ -65,6 +65,7 @@ import {useActivitySubscriptionsNudged} from '#/storage/hooks/activity-subscript
 type Props = NativeStackScreenProps<CommonNavigatorParams, 'Settings'>
 export function SettingsScreen({}: Props) {
   const {_} = useLingui()
+  const t = useTheme()
   const reducedMotion = useReducedMotion()
   const {logoutEveryAccount} = useSessionApi()
   const {accounts, currentAccount} = useSession()
@@ -184,7 +185,27 @@ export function SettingsScreen({}: Props) {
             label={_(msg`Verifiable credentials`)}>
             <SettingsList.ItemIcon icon={ShieldIcon} />
             <SettingsList.ItemText>
-              <Trans>Verifiable credentials</Trans>
+              <View style={[a.flex_row, a.align_center, a.gap_xs]}>
+                <Text>
+                  <Trans>Verifiable credentials</Trans>
+                </Text>
+                <View
+                  style={[
+                    a.px_xs,
+                    a.py_xs,
+                    a.rounded_sm,
+                    {backgroundColor: t.palette.positive_25},
+                  ]}>
+                  <Text
+                    style={[
+                      a.text_xs,
+                      {color: t.palette.positive_700},
+                      a.font_bold,
+                    ]}>
+                    DEMO
+                  </Text>
+                </View>
+              </View>
             </SettingsList.ItemText>
           </SettingsList.LinkItem>
           <SettingsList.LinkItem

--- a/src/screens/Settings/VerifiableCredentialsSettings.tsx
+++ b/src/screens/Settings/VerifiableCredentialsSettings.tsx
@@ -39,6 +39,7 @@ import {AccountVerificationBadge} from '#/components/icons/AccountVerificationBa
 import {AgeVerificationBadge} from '#/components/icons/AgeVerificationBadge'
 import {Shield_Stroke2_Corner0_Rounded as ShieldIcon} from '#/components/icons/Shield'
 import {VerifiedCheck} from '#/components/icons/VerifiedCheck'
+import {Warning_Stroke2_Corner0_Rounded as WarningIcon} from '#/components/icons/Warning'
 import * as Layout from '#/components/Layout'
 import {Text} from '#/components/Typography'
 
@@ -275,6 +276,42 @@ export function VerifiableCredentialsSettingsScreen({}: Props) {
         <Layout.Header.Slot />
       </Layout.Header.Outer>
       <Layout.Content>
+        {/* Demonstration Banner */}
+        <View
+          style={[
+            a.mx_md,
+            a.mt_md,
+            a.mb_lg,
+            a.p_md,
+            a.rounded_md,
+            {backgroundColor: t.palette.negative_25},
+            {borderWidth: 1, borderColor: t.palette.negative_200},
+          ]}>
+          <View
+            style={[
+              a.flex_row,
+              a.align_center,
+              a.justify_center,
+              a.gap_sm,
+              a.mb_sm,
+            ]}>
+            <WarningIcon size="md" fill={t.palette.negative_700} />
+            <Text
+              style={[
+                a.text_md,
+                {color: t.palette.negative_700},
+                a.font_bold,
+                a.text_center,
+              ]}>
+              Verifiable Credentials - Demonstration Environment
+            </Text>
+          </View>
+          <Text
+            style={[a.text_sm, {color: t.palette.negative_700}, a.text_center]}>
+            This feature is currently in testing phase and not production-ready.
+          </Text>
+        </View>
+
         <View style={[a.px_md, a.py_lg]}>
           {/* Available Verifications */}
           <Text style={[a.font_bold, a.text_lg, a.mb_md]}>


### PR DESCRIPTION
## Changes
- Add "DEMO" badge to main settings menu next to "Verifiable credentials"
- Add yellow warning banner on VC settings page
- Banner shows "Verifiable Credentials - Demonstration Environment" with warning icon