### PR TITLE
Change Age Verification Threshold from 21+ to 18+

### DIFF
--- a/__tests__/lib/api/credentials/proof-requests.test.ts
+++ b/__tests__/lib/api/credentials/proof-requests.test.ts
@@ -48,7 +48,7 @@ describe('ProofRequestsAPI', () => {
               age_verification: {
                 name: 'date_of_birth',
                 p_type: '<=',
-                p_value: 20030101,
+                p_value: 20060101,
                 restrictions: [
                   {
                     cred_def_id: 'test-cred-def-123',

--- a/__tests__/lib/api/credentials/verification-processor.test.ts
+++ b/__tests__/lib/api/credentials/verification-processor.test.ts
@@ -18,7 +18,7 @@ describe('VerificationProcessor', () => {
           handle: 'alice.bsky.social',
           displayName: 'Alice Johnson',
           subject: 'did:plc:alice123',
-          assertion: 'I assert that I am over 21 years of age',
+          assertion: 'I assert that I am over 18 years of age',
           createdAt: '2024-01-15T10:30:00Z',
           credential: {
             uri: 'https://verifier.example.com/proof/age123',
@@ -73,7 +73,7 @@ describe('VerificationProcessor', () => {
           handle: 'bob.bsky.social',
           displayName: 'Bob Smith',
           subject: 'did:plc:bob123',
-          assertion: 'I assert that I am over 21 years of age',
+          assertion: 'I assert that I am over 18 years of age',
           createdAt: '2024-01-10T08:00:00Z', // Older
           credential: {
             uri: 'https://verifier.example.com/proof/age1',
@@ -89,7 +89,7 @@ describe('VerificationProcessor', () => {
           handle: 'bob.bsky.social',
           displayName: 'Bob Smith',
           subject: 'did:plc:bob123',
-          assertion: 'I assert that I am over 21 years of age',
+          assertion: 'I assert that I am over 18 years of age',
           createdAt: '2024-01-20T10:00:00Z', // Newer
           credential: {
             uri: 'https://verifier.example.com/proof/age2',
@@ -170,7 +170,7 @@ describe('VerificationProcessor', () => {
           handle: 'valid.bsky.social',
           displayName: 'Valid User',
           subject: 'did:plc:valid123',
-          assertion: 'I assert that I am over 21 years of age',
+          assertion: 'I assert that I am over 18 years of age',
           createdAt: '2024-01-15T12:00:00Z',
           credential: {
             uri: 'https://verifier.example.com/proof/valid123',
@@ -186,7 +186,7 @@ describe('VerificationProcessor', () => {
           handle: 'invalid.bsky.social',
           displayName: 'Invalid User',
           subject: 'did:plc:invalid123',
-          assertion: 'I assert that I am over 21 years of age',
+          assertion: 'I assert that I am over 18 years of age',
           createdAt: '2024-01-15T12:00:00Z',
           credential: {
             uri: 'https://verifier.example.com/proof/invalid123',
@@ -379,7 +379,7 @@ describe('VerificationProcessor', () => {
         handle: 'test.bsky.social',
         displayName: 'Test User',
         subject: 'did:plc:test123',
-        assertion: 'I assert that I am over 21 years of age',
+        assertion: 'I assert that I am over 18 years of age',
         createdAt: '2024-01-15T10:30:00Z',
         credential: {
           uri: 'https://verifier.example.com/proof/test123',
@@ -432,7 +432,7 @@ describe('VerificationProcessor', () => {
         handle: 'test.bsky.social',
         displayName: 'Test User',
         subject: 'did:plc:test123',
-        assertion: 'I assert that I am over 21 years of age',
+        assertion: 'I assert that I am over 18 years of age',
         createdAt: 'invalid-date',
         credential: {
           uri: 'https://verifier.example.com/proof/test123',

--- a/__tests__/lib/api/credentials/verification-record.test.ts
+++ b/__tests__/lib/api/credentials/verification-record.test.ts
@@ -117,7 +117,7 @@ describe('VerificationRecord API', () => {
           handle: 'test.user.bsky.social',
           displayName: 'Test User',
           subject: 'did:plc:test123',
-          assertion: expect.stringContaining('21 years of age'),
+          assertion: expect.stringContaining('18 years of age'),
           createdAt: expect.any(String),
           credential: expect.objectContaining({
             type: ['VerifiableCredential', 'AnonCred', 'AgeVerification'],
@@ -258,7 +258,7 @@ describe('VerificationRecord API', () => {
             handle: 'test.user.bsky.social',
             displayName: 'Test User',
             subject: 'did:plc:test123',
-            assertion: 'I assert that I am over 21 years of age',
+            assertion: 'I assert that I am over 18 years of age',
             createdAt: '2024-01-15T10:30:00Z',
             credential: {
               type: ['VerifiableCredential', 'AgeVerification'],

--- a/src/components/verification/AgeVerificationDialog.tsx
+++ b/src/components/verification/AgeVerificationDialog.tsx
@@ -70,7 +70,7 @@ function Inner({
           {ageStatus.verified ? (
             <Trans>
               This account has an age verification badge because it has been
-              verified to be over 21 years of age through a trusted verification
+              verified to be over 18 years of age through a trusted verification
               process.
             </Trans>
           ) : (

--- a/src/lib/api/credentials/index.ts
+++ b/src/lib/api/credentials/index.ts
@@ -16,16 +16,16 @@ export class CredentialsAPI {
   }
 
   async requestAgeProof(connectionId: string, credentialDefinitionId: string) {
-    // Calculate 21+ age threshold
+    // Calculate 18+ age threshold
     const year = new Date().getFullYear()
-    const twentyOneYearsAgo = new Date()
-    twentyOneYearsAgo.setFullYear(year - 21)
+    const eighteenYearsAgo = new Date()
+    eighteenYearsAgo.setFullYear(year - 18)
 
     // Calculate threshold in YYYYMMDD format
-    const twentyOneThreshold = parseInt(
-      twentyOneYearsAgo.getFullYear() +
-        String(twentyOneYearsAgo.getMonth() + 1).padStart(2, '0') +
-        String(twentyOneYearsAgo.getDate()).padStart(2, '0'),
+    const eighteenThreshold = parseInt(
+      eighteenYearsAgo.getFullYear() +
+        String(eighteenYearsAgo.getMonth() + 1).padStart(2, '0') +
+        String(eighteenYearsAgo.getDate()).padStart(2, '0'),
       10,
     )
 
@@ -61,7 +61,7 @@ export class CredentialsAPI {
             age_verification: {
               name: 'date_of_birth',
               p_type: '<=',
-              p_value: twentyOneThreshold,
+              p_value: eighteenThreshold,
               restrictions: [
                 {
                   cred_def_id: credentialDefinitionId,

--- a/src/lib/api/credentials/verification-record.ts
+++ b/src/lib/api/credentials/verification-record.ts
@@ -43,7 +43,7 @@ export interface CredentialData {
 
 // Individual verification configurations
 const AGE_VERIFICATION_CONFIG: VerificationConfig = {
-  assertion: 'I assert that I am over 21 years of age',
+  assertion: 'I assert that I am over 18 years of age',
   types: ['VerifiableCredential', 'AnonCred', 'AgeVerification'],
   purposes: ['ProofOfMajorityAge'],
 }


### PR DESCRIPTION
## Changes
- Update age verification proof request logic from 21+ to 18+ threshold
- Change UI text from "over 21 years of age" to "over 18 years of age"
- Update verification record assertions to reflect 18+ requirement
- Fix all test files to use new 18+ threshold