### PR TITLE
Delete Verification Feature & Schema Update

### DIFF
--- a/src/lib/api/credentials/index.ts
+++ b/src/lib/api/credentials/index.ts
@@ -88,8 +88,8 @@ export class CredentialsAPI {
       },
       presentation_request: {
         anoncreds: {
-          name: 'X Account Verification',
-          version: '1.0',
+          name: 'account_verification',
+          version: '1.1',
           requested_attributes: {
             screen_name: {
               name: 'screen_name',
@@ -107,8 +107,16 @@ export class CredentialsAPI {
                 },
               ],
             },
-            host: {
-              name: 'host',
+            proof_id: {
+              name: 'proof_id',
+              restrictions: [
+                {
+                  cred_def_id: credentialDefinitionId,
+                },
+              ],
+            },
+            notarization: {
+              name: 'notarization',
               restrictions: [
                 {
                   cred_def_id: credentialDefinitionId,

--- a/src/lib/api/credentials/verification-record.ts
+++ b/src/lib/api/credentials/verification-record.ts
@@ -426,6 +426,47 @@ export async function getVerificationRecord(
 }
 
 /**
+ * Delete a verification record by rkey
+ */
+export async function deleteVerificationRecord(
+  rkey: string,
+  sessionData?: {
+    currentAccount: any
+    agent: any
+  },
+): Promise<void> {
+  if (!sessionData) {
+    throw new Error('Session data required for deleting verification records')
+  }
+
+  const {currentAccount, agent} = sessionData
+
+  if (!currentAccount?.did) {
+    throw new Error('No authenticated user found')
+  }
+
+  try {
+    await agent.api.com.atproto.repo.deleteRecord({
+      repo: currentAccount.did,
+      collection: 'app.bsky.graph.verification',
+      rkey: rkey,
+    })
+
+    logger.info('Verification record deleted successfully', {
+      rkey,
+      userDid: currentAccount.did,
+    })
+  } catch (error) {
+    logger.error('Failed to delete verification record', {
+      error,
+      rkey,
+      userDid: currentAccount.did,
+    })
+    throw new Error(`Failed to delete verification record: ${error}`)
+  }
+}
+
+/**
  * List all verification records for a user
  */
 export async function listVerificationRecords(

--- a/src/lib/constants.ts
+++ b/src/lib/constants.ts
@@ -20,7 +20,7 @@ export const CREDENTIAL_VERIFIER_ENDPOINT =
 // Credential Definition IDs (not sensitive). In prod case we probably need to interact with an API
 export const AGE_CRED_DEF_ID =
   'VPSZ5XQA8EULcjUxL9HTfQ:3:CL:39:mock_mobile_drivers_license'
-export const ACCOUNT_CRED_DEF_ID = 'VPSZ5XQA8EULcjUxL9HTfQ:3:CL:59:x_account'
+export const ACCOUNT_CRED_DEF_ID = 'VPSZ5XQA8EULcjUxL9HTfQ:3:CL:69:x_account'
 // HACK
 // Yes, this is exactly what it looks like. It's a hard-coded constant
 // reflecting the number of new users in the last week. We don't have


### PR DESCRIPTION
## Summary
Delete verification credentials from the settings page and updates the account verification schema.

### Delete Verification Feature
- Added delete functionality for verified credentials in settings
- Confirmation dialog before deletion
- Cache invalidation for UI update

### Account Verification Schema Update
- Updated schema
- Added new attributes:
  - `notarization` - Notarization data
- Removed attribute:
  - `host` - No longer needed
- Updated credential definition to `VPSZ5XQA8EULcjUxL9HTfQ:3:CL:69:x_account`
